### PR TITLE
Use module path for asset references

### DIFF
--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,8 +1,9 @@
 Hooks.once('diceSoNiceReady', (dice3d) => {
+  const mod = game.modules.get('skykings-dice').path;
   dice3d.addTexture('skystone', {
     name: 'Sky Stone',
     composite: 'multiply',
-    source: 'modules/skykings-dice/assets/textures/stone.png'
+    source: `${mod}/assets/textures/stone.png`
   });
 
   dice3d.addColorset({
@@ -17,7 +18,7 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
     material: 'metal'
   }, 'preferred');
 
-  const base = 'modules/skykings-dice/assets/labels';
+  const base = `${mod}/assets/labels`;
   const L = (die, faces) => faces.map(f => `${base}/${die}/${f}.png`);
 
   dice3d.addDicePreset({ type: 'd4',  labels: L('d4',  [1,2,3,4]), colorset: 'Sky Kings Tomb', system: 'standard' });


### PR DESCRIPTION
## Summary
- reference module path when loading textures and labels

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6ba4ca088327ad1cd933a6f442f8