### PR TITLE
feat: register custom Dice So Nice system

### DIFF
--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,5 +1,6 @@
 Hooks.once('diceSoNiceReady', (dice3d) => {
   const mod = game.modules.get('skykings-dice').path;
+  dice3d.addSystem({ id: 'skykings-dice', name: "Sky King's Tomb" });
   dice3d.addTexture('skystone', {
     name: 'Sky Stone',
     composite: 'multiply',
@@ -21,11 +22,11 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
   const base = `${mod}/assets/labels`;
   const L = (die, faces) => faces.map(f => `${base}/${die}/${f}.png`);
 
-  dice3d.addDicePreset({ type: 'd4',  labels: L('d4',  [1,2,3,4]), colorset: 'Sky Kings Tomb', system: 'standard' });
-  dice3d.addDicePreset({ type: 'd6',  labels: L('d6',  [1,2,3,4,5,6]), colorset: 'Sky Kings Tomb', system: 'standard' });
-  dice3d.addDicePreset({ type: 'd8',  labels: L('d8',  [1,2,3,4,5,6,7,8]), colorset: 'Sky Kings Tomb', system: 'standard' });
-  dice3d.addDicePreset({ type: 'd10', labels: L('d10', [0,1,2,3,4,5,6,7,8,9]), colorset: 'Sky Kings Tomb', system: 'standard' });
-  dice3d.addDicePreset({ type: 'd12', labels: L('d12', [1,2,3,4,5,6,7,8,9,10,11,12]), colorset: 'Sky Kings Tomb', system: 'standard' });
-  dice3d.addDicePreset({ type: 'd20', labels: L('d20', [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]), colorset: 'Sky Kings Tomb', system: 'standard' });
-  dice3d.addDicePreset({ type: 'd100',labels: L('d100',['00','10','20','30','40','50','60','70','80','90']), colorset: 'Sky Kings Tomb', system: 'standard' });
+  dice3d.addDicePreset({ type: 'd4',   labels: L('d4',  [1,2,3,4]),                      colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
+  dice3d.addDicePreset({ type: 'd6',   labels: L('d6',  [1,2,3,4,5,6]),                  colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
+  dice3d.addDicePreset({ type: 'd8',   labels: L('d8',  [1,2,3,4,5,6,7,8]),              colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
+  dice3d.addDicePreset({ type: 'd10',  labels: L('d10', [0,1,2,3,4,5,6,7,8,9]),          colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
+  dice3d.addDicePreset({ type: 'd12',  labels: L('d12', [1,2,3,4,5,6,7,8,9,10,11,12]),   colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
+  dice3d.addDicePreset({ type: 'd20',  labels: L('d20', [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]), colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
+  dice3d.addDicePreset({ type: 'd100', labels: L('d100',['00','10','20','30','40','50','60','70','80','90']),  colorset: 'Sky Kings Tomb', system: 'skykings-dice' });
 });


### PR DESCRIPTION
## Summary
- register the module as its own Dice So Nice system
- point all dice presets at the custom system

## Testing
- `node --check scripts/register.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ca75c5483278f2f5804420cbbd6